### PR TITLE
Fix for unknown hardware models on node detail page

### DIFF
--- a/meshtastic_support.py
+++ b/meshtastic_support.py
@@ -116,6 +116,10 @@ class HardwareModel(Enum):
     GAT562_MESH_TRIAL_TRACKER = 104
     PRIVATE_HW = 255
 
+    @classmethod
+    def _missing_(cls, value):
+        return HardwareModel.UNSET
+
 class Role(Enum):
     """
     Meshtastic node roles


### PR DESCRIPTION
So when a node reports an unknown hardware ID (in my case, saw one with ID 105), the Node Details page crashes because it attempts to instantiate the HardwareModel enum with the ID in order to get a graphic for the node. This change lets that process fail gracefully.